### PR TITLE
fix: provider definition had invalid new line in first argument

### DIFF
--- a/src/DependencyInjection/GeekCellImagekitExtension.php
+++ b/src/DependencyInjection/GeekCellImagekitExtension.php
@@ -48,8 +48,8 @@ final class GeekCellImagekitExtension extends Extension
 
         $providerDefiniton = (new Definition(Provider::class))
                 ->setFactory([Provider::class, 'create'])
-                ->setArguments(['
-                    %geek_cell_imagekit.public_key%',
+                ->setArguments([
+                    '%geek_cell_imagekit.public_key%',
                     '%geek_cell_imagekit.private_key%',
                     $providerEndpoint,
                 ])


### PR DESCRIPTION
The configuration is invalid in that it has a new line in the first argument listed. This causes breaking behaviour when clearing the cache in symfony 6.3 while it worked just fine in symfony 6.2